### PR TITLE
fix: address PR review issues - add i18n support and fix duplicate no…

### DIFF
--- a/_locales/bn/messages.json
+++ b/_locales/bn/messages.json
@@ -505,4 +505,59 @@
   "pacUrlHelp": {
     "message": "PAC স্ক্রিপ্ট এই URL থেকে লোড হবে"
   }
+  },
+  "autoReloadEnabled": {
+    "message": "Auto-reload enabled"
+  },
+  "autoReloadDisabled": {
+    "message": "Auto-reload disabled"
+  },
+  "systemNotifications": {
+    "message": "System Notifications"
+  },
+  "systemNotificationsEnabled": {
+    "message": "System notifications enabled"
+  },
+  "systemNotificationsDisabled": {
+    "message": "System notifications disabled"
+  },
+  "systemNotificationsTooltip": {
+    "message": "Enable Chrome notifications for background events"
+  },
+  "systemNotificationsDescription": {
+    "message": "Show system notifications for proxy switches and errors"
+  },
+  "errorFailedToLoadSettings": {
+    "message": "Failed to load settings"
+  },
+  "errorFailedToSetProxy": {
+    "message": "Failed to set proxy configuration"
+  },
+  "errorFailedToClearProxy": {
+    "message": "Failed to clear proxy configuration"
+  },
+  "errorFailedToDeleteScript": {
+    "message": "Failed to delete script"
+  },
+  "proxySwitched": {
+    "message": "Proxy Switched"
+  },
+  "proxySwitchedTo": {
+    "message": "Switched to \"$1\""
+  },
+  "proxySwitchedToForHost": {
+    "message": "Switched to \"$1\" for $2"
+  },
+  "proxyError": {
+    "message": "Proxy Error"
+  },
+  "proxyErrorMessage": {
+    "message": "Failed to use \"$1\": $2"
+  },
+  "pacScriptPreview": {
+    "message": "PAC Script Preview (Read-only)"
+  },
+  "pacScriptFetchError": {
+    "message": "Failed to fetch PAC script from URL"
+  }
 }

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -504,5 +504,59 @@
   },
   "pacUrlHelp": {
     "message": "PAC-Skript wird von dieser URL geladen"
+  },
+  "autoReloadEnabled": {
+    "message": "Auto-reload enabled"
+  },
+  "autoReloadDisabled": {
+    "message": "Auto-reload disabled"
+  },
+  "systemNotifications": {
+    "message": "System Notifications"
+  },
+  "systemNotificationsEnabled": {
+    "message": "System notifications enabled"
+  },
+  "systemNotificationsDisabled": {
+    "message": "System notifications disabled"
+  },
+  "systemNotificationsTooltip": {
+    "message": "Enable Chrome notifications for background events"
+  },
+  "systemNotificationsDescription": {
+    "message": "Show system notifications for proxy switches and errors"
+  },
+  "errorFailedToLoadSettings": {
+    "message": "Failed to load settings"
+  },
+  "errorFailedToSetProxy": {
+    "message": "Failed to set proxy configuration"
+  },
+  "errorFailedToClearProxy": {
+    "message": "Failed to clear proxy configuration"
+  },
+  "errorFailedToDeleteScript": {
+    "message": "Failed to delete script"
+  },
+  "proxySwitched": {
+    "message": "Proxy Switched"
+  },
+  "proxySwitchedTo": {
+    "message": "Switched to \"$1\""
+  },
+  "proxySwitchedToForHost": {
+    "message": "Switched to \"$1\" for $2"
+  },
+  "proxyError": {
+    "message": "Proxy Error"
+  },
+  "proxyErrorMessage": {
+    "message": "Failed to use \"$1\": $2"
+  },
+  "pacScriptPreview": {
+    "message": "PAC Script Preview (Read-only)"
+  },
+  "pacScriptFetchError": {
+    "message": "Failed to fetch PAC script from URL"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -501,5 +501,59 @@
   },
   "pacUrlHelp": {
     "message": "PAC script will be loaded from this URL"
+  },
+  "autoReloadEnabled": {
+    "message": "Auto-reload enabled"
+  },
+  "autoReloadDisabled": {
+    "message": "Auto-reload disabled"
+  },
+  "systemNotifications": {
+    "message": "System Notifications"
+  },
+  "systemNotificationsEnabled": {
+    "message": "System notifications enabled"
+  },
+  "systemNotificationsDisabled": {
+    "message": "System notifications disabled"
+  },
+  "systemNotificationsTooltip": {
+    "message": "Enable Chrome notifications for background events"
+  },
+  "systemNotificationsDescription": {
+    "message": "Show system notifications for proxy switches and errors"
+  },
+  "errorFailedToLoadSettings": {
+    "message": "Failed to load settings"
+  },
+  "errorFailedToSetProxy": {
+    "message": "Failed to set proxy configuration"
+  },
+  "errorFailedToClearProxy": {
+    "message": "Failed to clear proxy configuration"
+  },
+  "errorFailedToDeleteScript": {
+    "message": "Failed to delete script"
+  },
+  "proxySwitched": {
+    "message": "Proxy Switched"
+  },
+  "proxySwitchedTo": {
+    "message": "Switched to \"$1\""
+  },
+  "proxySwitchedToForHost": {
+    "message": "Switched to \"$1\" for $2"
+  },
+  "proxyError": {
+    "message": "Proxy Error"
+  },
+  "proxyErrorMessage": {
+    "message": "Failed to use \"$1\": $2"
+  },
+  "pacScriptPreview": {
+    "message": "PAC Script Preview (Read-only)"
+  },
+  "pacScriptFetchError": {
+    "message": "Failed to fetch PAC script from URL"
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -505,4 +505,59 @@
   "pacUrlHelp": {
     "message": "El script PAC se cargará desde esta URL"
   }
+  },
+  "autoReloadEnabled": {
+    "message": "Auto-reload enabled"
+  },
+  "autoReloadDisabled": {
+    "message": "Auto-reload disabled"
+  },
+  "systemNotifications": {
+    "message": "System Notifications"
+  },
+  "systemNotificationsEnabled": {
+    "message": "System notifications enabled"
+  },
+  "systemNotificationsDisabled": {
+    "message": "System notifications disabled"
+  },
+  "systemNotificationsTooltip": {
+    "message": "Enable Chrome notifications for background events"
+  },
+  "systemNotificationsDescription": {
+    "message": "Show system notifications for proxy switches and errors"
+  },
+  "errorFailedToLoadSettings": {
+    "message": "Failed to load settings"
+  },
+  "errorFailedToSetProxy": {
+    "message": "Failed to set proxy configuration"
+  },
+  "errorFailedToClearProxy": {
+    "message": "Failed to clear proxy configuration"
+  },
+  "errorFailedToDeleteScript": {
+    "message": "Failed to delete script"
+  },
+  "proxySwitched": {
+    "message": "Proxy Switched"
+  },
+  "proxySwitchedTo": {
+    "message": "Switched to \"$1\""
+  },
+  "proxySwitchedToForHost": {
+    "message": "Switched to \"$1\" for $2"
+  },
+  "proxyError": {
+    "message": "Proxy Error"
+  },
+  "proxyErrorMessage": {
+    "message": "Failed to use \"$1\": $2"
+  },
+  "pacScriptPreview": {
+    "message": "PAC Script Preview (Read-only)"
+  },
+  "pacScriptFetchError": {
+    "message": "Failed to fetch PAC script from URL"
+  }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -505,4 +505,59 @@
   "pacUrlHelp": {
     "message": "Le script PAC sera chargé depuis cette URL"
   }
+  },
+  "autoReloadEnabled": {
+    "message": "Auto-reload enabled"
+  },
+  "autoReloadDisabled": {
+    "message": "Auto-reload disabled"
+  },
+  "systemNotifications": {
+    "message": "System Notifications"
+  },
+  "systemNotificationsEnabled": {
+    "message": "System notifications enabled"
+  },
+  "systemNotificationsDisabled": {
+    "message": "System notifications disabled"
+  },
+  "systemNotificationsTooltip": {
+    "message": "Enable Chrome notifications for background events"
+  },
+  "systemNotificationsDescription": {
+    "message": "Show system notifications for proxy switches and errors"
+  },
+  "errorFailedToLoadSettings": {
+    "message": "Failed to load settings"
+  },
+  "errorFailedToSetProxy": {
+    "message": "Failed to set proxy configuration"
+  },
+  "errorFailedToClearProxy": {
+    "message": "Failed to clear proxy configuration"
+  },
+  "errorFailedToDeleteScript": {
+    "message": "Failed to delete script"
+  },
+  "proxySwitched": {
+    "message": "Proxy Switched"
+  },
+  "proxySwitchedTo": {
+    "message": "Switched to \"$1\""
+  },
+  "proxySwitchedToForHost": {
+    "message": "Switched to \"$1\" for $2"
+  },
+  "proxyError": {
+    "message": "Proxy Error"
+  },
+  "proxyErrorMessage": {
+    "message": "Failed to use \"$1\": $2"
+  },
+  "pacScriptPreview": {
+    "message": "PAC Script Preview (Read-only)"
+  },
+  "pacScriptFetchError": {
+    "message": "Failed to fetch PAC script from URL"
+  }
 }

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -505,4 +505,59 @@
   "pacUrlHelp": {
     "message": "PAC स्क्रिप्ट इस URL से लोड की जाएगी"
   }
+  },
+  "autoReloadEnabled": {
+    "message": "Auto-reload enabled"
+  },
+  "autoReloadDisabled": {
+    "message": "Auto-reload disabled"
+  },
+  "systemNotifications": {
+    "message": "System Notifications"
+  },
+  "systemNotificationsEnabled": {
+    "message": "System notifications enabled"
+  },
+  "systemNotificationsDisabled": {
+    "message": "System notifications disabled"
+  },
+  "systemNotificationsTooltip": {
+    "message": "Enable Chrome notifications for background events"
+  },
+  "systemNotificationsDescription": {
+    "message": "Show system notifications for proxy switches and errors"
+  },
+  "errorFailedToLoadSettings": {
+    "message": "Failed to load settings"
+  },
+  "errorFailedToSetProxy": {
+    "message": "Failed to set proxy configuration"
+  },
+  "errorFailedToClearProxy": {
+    "message": "Failed to clear proxy configuration"
+  },
+  "errorFailedToDeleteScript": {
+    "message": "Failed to delete script"
+  },
+  "proxySwitched": {
+    "message": "Proxy Switched"
+  },
+  "proxySwitchedTo": {
+    "message": "Switched to \"$1\""
+  },
+  "proxySwitchedToForHost": {
+    "message": "Switched to \"$1\" for $2"
+  },
+  "proxyError": {
+    "message": "Proxy Error"
+  },
+  "proxyErrorMessage": {
+    "message": "Failed to use \"$1\": $2"
+  },
+  "pacScriptPreview": {
+    "message": "PAC Script Preview (Read-only)"
+  },
+  "pacScriptFetchError": {
+    "message": "Failed to fetch PAC script from URL"
+  }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -505,4 +505,59 @@
   "pacUrlHelp": {
     "message": "PACスクリプトはこのURLから読み込まれます"
   }
+  },
+  "autoReloadEnabled": {
+    "message": "Auto-reload enabled"
+  },
+  "autoReloadDisabled": {
+    "message": "Auto-reload disabled"
+  },
+  "systemNotifications": {
+    "message": "System Notifications"
+  },
+  "systemNotificationsEnabled": {
+    "message": "System notifications enabled"
+  },
+  "systemNotificationsDisabled": {
+    "message": "System notifications disabled"
+  },
+  "systemNotificationsTooltip": {
+    "message": "Enable Chrome notifications for background events"
+  },
+  "systemNotificationsDescription": {
+    "message": "Show system notifications for proxy switches and errors"
+  },
+  "errorFailedToLoadSettings": {
+    "message": "Failed to load settings"
+  },
+  "errorFailedToSetProxy": {
+    "message": "Failed to set proxy configuration"
+  },
+  "errorFailedToClearProxy": {
+    "message": "Failed to clear proxy configuration"
+  },
+  "errorFailedToDeleteScript": {
+    "message": "Failed to delete script"
+  },
+  "proxySwitched": {
+    "message": "Proxy Switched"
+  },
+  "proxySwitchedTo": {
+    "message": "Switched to \"$1\""
+  },
+  "proxySwitchedToForHost": {
+    "message": "Switched to \"$1\" for $2"
+  },
+  "proxyError": {
+    "message": "Proxy Error"
+  },
+  "proxyErrorMessage": {
+    "message": "Failed to use \"$1\": $2"
+  },
+  "pacScriptPreview": {
+    "message": "PAC Script Preview (Read-only)"
+  },
+  "pacScriptFetchError": {
+    "message": "Failed to fetch PAC script from URL"
+  }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -505,4 +505,59 @@
   "pacUrlHelp": {
     "message": "PAC 스크립트가 이 URL에서 로드됩니다"
   }
+  },
+  "autoReloadEnabled": {
+    "message": "Auto-reload enabled"
+  },
+  "autoReloadDisabled": {
+    "message": "Auto-reload disabled"
+  },
+  "systemNotifications": {
+    "message": "System Notifications"
+  },
+  "systemNotificationsEnabled": {
+    "message": "System notifications enabled"
+  },
+  "systemNotificationsDisabled": {
+    "message": "System notifications disabled"
+  },
+  "systemNotificationsTooltip": {
+    "message": "Enable Chrome notifications for background events"
+  },
+  "systemNotificationsDescription": {
+    "message": "Show system notifications for proxy switches and errors"
+  },
+  "errorFailedToLoadSettings": {
+    "message": "Failed to load settings"
+  },
+  "errorFailedToSetProxy": {
+    "message": "Failed to set proxy configuration"
+  },
+  "errorFailedToClearProxy": {
+    "message": "Failed to clear proxy configuration"
+  },
+  "errorFailedToDeleteScript": {
+    "message": "Failed to delete script"
+  },
+  "proxySwitched": {
+    "message": "Proxy Switched"
+  },
+  "proxySwitchedTo": {
+    "message": "Switched to \"$1\""
+  },
+  "proxySwitchedToForHost": {
+    "message": "Switched to \"$1\" for $2"
+  },
+  "proxyError": {
+    "message": "Proxy Error"
+  },
+  "proxyErrorMessage": {
+    "message": "Failed to use \"$1\": $2"
+  },
+  "pacScriptPreview": {
+    "message": "PAC Script Preview (Read-only)"
+  },
+  "pacScriptFetchError": {
+    "message": "Failed to fetch PAC script from URL"
+  }
 }

--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -505,4 +505,59 @@
   "pacUrlHelp": {
     "message": "O script PAC será carregado a partir desta URL"
   }
+  },
+  "autoReloadEnabled": {
+    "message": "Auto-reload enabled"
+  },
+  "autoReloadDisabled": {
+    "message": "Auto-reload disabled"
+  },
+  "systemNotifications": {
+    "message": "System Notifications"
+  },
+  "systemNotificationsEnabled": {
+    "message": "System notifications enabled"
+  },
+  "systemNotificationsDisabled": {
+    "message": "System notifications disabled"
+  },
+  "systemNotificationsTooltip": {
+    "message": "Enable Chrome notifications for background events"
+  },
+  "systemNotificationsDescription": {
+    "message": "Show system notifications for proxy switches and errors"
+  },
+  "errorFailedToLoadSettings": {
+    "message": "Failed to load settings"
+  },
+  "errorFailedToSetProxy": {
+    "message": "Failed to set proxy configuration"
+  },
+  "errorFailedToClearProxy": {
+    "message": "Failed to clear proxy configuration"
+  },
+  "errorFailedToDeleteScript": {
+    "message": "Failed to delete script"
+  },
+  "proxySwitched": {
+    "message": "Proxy Switched"
+  },
+  "proxySwitchedTo": {
+    "message": "Switched to \"$1\""
+  },
+  "proxySwitchedToForHost": {
+    "message": "Switched to \"$1\" for $2"
+  },
+  "proxyError": {
+    "message": "Proxy Error"
+  },
+  "proxyErrorMessage": {
+    "message": "Failed to use \"$1\": $2"
+  },
+  "pacScriptPreview": {
+    "message": "PAC Script Preview (Read-only)"
+  },
+  "pacScriptFetchError": {
+    "message": "Failed to fetch PAC script from URL"
+  }
 }

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -505,4 +505,59 @@
   "pacUrlHelp": {
     "message": "Scriptul PAC va fi încărcat de la acest URL"
   }
+  },
+  "autoReloadEnabled": {
+    "message": "Auto-reload enabled"
+  },
+  "autoReloadDisabled": {
+    "message": "Auto-reload disabled"
+  },
+  "systemNotifications": {
+    "message": "System Notifications"
+  },
+  "systemNotificationsEnabled": {
+    "message": "System notifications enabled"
+  },
+  "systemNotificationsDisabled": {
+    "message": "System notifications disabled"
+  },
+  "systemNotificationsTooltip": {
+    "message": "Enable Chrome notifications for background events"
+  },
+  "systemNotificationsDescription": {
+    "message": "Show system notifications for proxy switches and errors"
+  },
+  "errorFailedToLoadSettings": {
+    "message": "Failed to load settings"
+  },
+  "errorFailedToSetProxy": {
+    "message": "Failed to set proxy configuration"
+  },
+  "errorFailedToClearProxy": {
+    "message": "Failed to clear proxy configuration"
+  },
+  "errorFailedToDeleteScript": {
+    "message": "Failed to delete script"
+  },
+  "proxySwitched": {
+    "message": "Proxy Switched"
+  },
+  "proxySwitchedTo": {
+    "message": "Switched to \"$1\""
+  },
+  "proxySwitchedToForHost": {
+    "message": "Switched to \"$1\" for $2"
+  },
+  "proxyError": {
+    "message": "Proxy Error"
+  },
+  "proxyErrorMessage": {
+    "message": "Failed to use \"$1\": $2"
+  },
+  "pacScriptPreview": {
+    "message": "PAC Script Preview (Read-only)"
+  },
+  "pacScriptFetchError": {
+    "message": "Failed to fetch PAC script from URL"
+  }
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -505,4 +505,59 @@
   "pacUrlHelp": {
     "message": "PAC-скрипт будет загружен с этого URL"
   }
+  },
+  "autoReloadEnabled": {
+    "message": "Auto-reload enabled"
+  },
+  "autoReloadDisabled": {
+    "message": "Auto-reload disabled"
+  },
+  "systemNotifications": {
+    "message": "System Notifications"
+  },
+  "systemNotificationsEnabled": {
+    "message": "System notifications enabled"
+  },
+  "systemNotificationsDisabled": {
+    "message": "System notifications disabled"
+  },
+  "systemNotificationsTooltip": {
+    "message": "Enable Chrome notifications for background events"
+  },
+  "systemNotificationsDescription": {
+    "message": "Show system notifications for proxy switches and errors"
+  },
+  "errorFailedToLoadSettings": {
+    "message": "Failed to load settings"
+  },
+  "errorFailedToSetProxy": {
+    "message": "Failed to set proxy configuration"
+  },
+  "errorFailedToClearProxy": {
+    "message": "Failed to clear proxy configuration"
+  },
+  "errorFailedToDeleteScript": {
+    "message": "Failed to delete script"
+  },
+  "proxySwitched": {
+    "message": "Proxy Switched"
+  },
+  "proxySwitchedTo": {
+    "message": "Switched to \"$1\""
+  },
+  "proxySwitchedToForHost": {
+    "message": "Switched to \"$1\" for $2"
+  },
+  "proxyError": {
+    "message": "Proxy Error"
+  },
+  "proxyErrorMessage": {
+    "message": "Failed to use \"$1\": $2"
+  },
+  "pacScriptPreview": {
+    "message": "PAC Script Preview (Read-only)"
+  },
+  "pacScriptFetchError": {
+    "message": "Failed to fetch PAC script from URL"
+  }
 }

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -505,4 +505,59 @@
   "pacUrlHelp": {
     "message": "PAC脚本将从此URL加载"
   }
+  },
+  "autoReloadEnabled": {
+    "message": "Auto-reload enabled"
+  },
+  "autoReloadDisabled": {
+    "message": "Auto-reload disabled"
+  },
+  "systemNotifications": {
+    "message": "System Notifications"
+  },
+  "systemNotificationsEnabled": {
+    "message": "System notifications enabled"
+  },
+  "systemNotificationsDisabled": {
+    "message": "System notifications disabled"
+  },
+  "systemNotificationsTooltip": {
+    "message": "Enable Chrome notifications for background events"
+  },
+  "systemNotificationsDescription": {
+    "message": "Show system notifications for proxy switches and errors"
+  },
+  "errorFailedToLoadSettings": {
+    "message": "Failed to load settings"
+  },
+  "errorFailedToSetProxy": {
+    "message": "Failed to set proxy configuration"
+  },
+  "errorFailedToClearProxy": {
+    "message": "Failed to clear proxy configuration"
+  },
+  "errorFailedToDeleteScript": {
+    "message": "Failed to delete script"
+  },
+  "proxySwitched": {
+    "message": "Proxy Switched"
+  },
+  "proxySwitchedTo": {
+    "message": "Switched to \"$1\""
+  },
+  "proxySwitchedToForHost": {
+    "message": "Switched to \"$1\" for $2"
+  },
+  "proxyError": {
+    "message": "Proxy Error"
+  },
+  "proxyErrorMessage": {
+    "message": "Failed to use \"$1\": $2"
+  },
+  "pacScriptPreview": {
+    "message": "PAC Script Preview (Read-only)"
+  },
+  "pacScriptFetchError": {
+    "message": "Failed to fetch PAC script from URL"
+  }
 }

--- a/src/components/ProxyConfig/ProxyConfigModal.svelte
+++ b/src/components/ProxyConfig/ProxyConfigModal.svelte
@@ -150,7 +150,7 @@
               errorMessage =
                 I18nService.getMessage('pacScriptFetchError') ||
                 'Failed to fetch PAC script from URL'
-              NotifyService.error(ERROR_TYPES.VALIDATION, error)
+              // Error is shown in modal via errorMessage, no need for toast notification
               return // Don't save if fetch fails
             }
           }

--- a/src/options/SettingsTab.svelte
+++ b/src/options/SettingsTab.svelte
@@ -45,14 +45,21 @@
 
   async function handleAutoReloadToggle(checked: boolean) {
     await settingsStore.updateSettings({ autoReloadOnProxySwitch: checked })
-    toastStore.show(checked ? 'Auto-reload enabled' : 'Auto-reload disabled', 'success')
+    toastStore.show(
+      checked
+        ? I18nService.getMessage('autoReloadEnabled')
+        : I18nService.getMessage('autoReloadDisabled'),
+      'success'
+    )
   }
 
   async function handleNotificationsToggle(checked: boolean) {
     notificationsEnabled = checked
     await StorageService.savePreferences({ notifications: checked })
     toastStore.show(
-      checked ? 'System notifications enabled' : 'System notifications disabled',
+      checked
+        ? I18nService.getMessage('systemNotificationsEnabled')
+        : I18nService.getMessage('systemNotificationsDisabled'),
       'success'
     )
   }
@@ -169,14 +176,14 @@
             <div class="flex-1">
               <div class="flex items-center gap-2">
                 <label class="text-base font-semibold cursor-pointer" for="notificationsToggle">
-                  System Notifications
+                  {I18nService.getMessage('systemNotifications')}
                 </label>
-                <Tooltip text="Enable Chrome notifications for background events" position="top">
+                <Tooltip text={I18nService.getMessage('systemNotificationsTooltip')} position="top">
                   <CircleQuestionMark size={16} class="text-slate-400 dark:text-slate-500" />
                 </Tooltip>
               </div>
               <Text as="p" size="sm" color="muted" classes="mt-1">
-                Show system notifications for proxy switches and errors
+                {I18nService.getMessage('systemNotificationsDescription')}
               </Text>
             </div>
           </FlexGroup>

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -3,6 +3,7 @@ import { StorageService } from './StorageService'
 import { ERROR_TYPES } from '@/interfaces'
 import { ALERT_TYPES } from '@/interfaces/error'
 import { toastStore, type ToastType } from '@/stores/toastStore'
+import { I18nService } from './i18n/i18nService'
 
 /**
  * Notification context determines where notifications are shown
@@ -213,13 +214,13 @@ export class NotificationService {
         return ALERT_TYPES.SAVE_FAILURE
       case ERROR_TYPES.FETCH_SETTINGS:
       case ERROR_TYPES.LOAD_SETTINGS:
-        return 'Failed to load settings'
+        return I18nService.getMessage('errorFailedToLoadSettings')
       case ERROR_TYPES.SET_PROXY:
-        return 'Failed to set proxy configuration'
+        return I18nService.getMessage('errorFailedToSetProxy')
       case ERROR_TYPES.CLEAR_PROXY:
-        return 'Failed to clear proxy configuration'
+        return I18nService.getMessage('errorFailedToClearProxy')
       case ERROR_TYPES.DELETE_SCRIPT:
-        return 'Failed to delete script'
+        return I18nService.getMessage('errorFailedToDeleteScript')
       default:
         return ALERT_TYPES.UNKNOWN_ERROR
     }
@@ -227,14 +228,21 @@ export class NotificationService {
 
   /**
    * Show a notification for proxy switching events (for automatic mode)
+   *
+   * @remarks
+   * This method is reserved for future automatic mode functionality.
+   * It is not currently used in the codebase but is prepared for when
+   * automatic proxy switching based on URLs is implemented.
+   *
+   * @see FEASIBILITY_STUDY_AUTOMATIC_MODE.md for implementation details
    */
   static async proxySwitch(proxyName: string, url?: string): Promise<void> {
     const message = url
-      ? `Switched to "${proxyName}" for ${new URL(url).hostname}`
-      : `Switched to "${proxyName}"`
+      ? I18nService.getMessage('proxySwitchedToForHost', [proxyName, new URL(url).hostname])
+      : I18nService.getMessage('proxySwitchedTo', [proxyName])
 
     await this.show({
-      title: 'Proxy Switched',
+      title: I18nService.getMessage('proxySwitched'),
       message,
       type: 'info',
       duration: 3000,
@@ -244,11 +252,17 @@ export class NotificationService {
 
   /**
    * Show a notification for proxy errors
+   *
+   * @remarks
+   * This method is reserved for future automatic mode functionality.
+   * It will be used to notify users when a proxy fails in automatic mode.
+   *
+   * @see FEASIBILITY_STUDY_AUTOMATIC_MODE.md for implementation details
    */
   static async proxyError(proxyName: string, error: string): Promise<void> {
     await this.show({
-      title: 'Proxy Error',
-      message: `Failed to use "${proxyName}": ${error}`,
+      title: I18nService.getMessage('proxyError'),
+      message: I18nService.getMessage('proxyErrorMessage', [proxyName, error]),
       type: 'error',
       duration: 5000,
       requireInteraction: true,


### PR DESCRIPTION
…tifications

This commit addresses all critical issues identified in PR #20 review:

1. Internationalization (i18n):
   - Added 18 missing i18n keys to all 12 locale files
   - Replaced hardcoded strings in SettingsTab.svelte with I18nService calls
   - Replaced hardcoded strings in NotificationService.ts with I18nService calls
   - Added i18n support for PAC script preview and error messages

2. Code Quality Improvements:
   - Removed duplicate error notification in ProxyConfigModal.svelte
   - Error is now shown only in modal UI, not as duplicate toast

3. Documentation:
   - Added JSDoc comments to proxySwitch() and proxyError() methods
   - Documented these methods as reserved for future automatic mode

Changes affect:
- All 12 locale files (_locales/*/messages.json)
- SettingsTab.svelte: Auto-reload and system notification strings
- NotificationService.ts: Error messages and proxy switch notifications
- ProxyConfigModal.svelte: Removed duplicate error notification

All user-facing strings are now properly internationalized and ready for translation.