### PR TITLE
ci: migrate CWS publish to API v2 service-account auth + environment gating

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@ This pipeline shape is shared across navbytes browser-extension repos
 | Scheduled Security Audit | `audit.yml` | Mondays 06:00 UTC | `bun audit --audit-level=moderate` — catches new advisories without a code change. |
 | Release Please | `release-please.yml` | Push to `main` | Maintains a rolling release PR from conventional commits. Merging it bumps `package.json` + `manifest.json` (via `release-please-config.json` extra-files) and updates `CHANGELOG.md`. |
 | Create Release | `release.yml` | `manifest.json` change on `main` | Tag-guarded (idempotent): tests, builds, packages `Pacify_<version>.zip`, extracts notes from `CHANGELOG.md`, creates the GitHub Release. |
-| Publish to Chrome Web Store | `publish-cws.yml` | Manual (Actions tab) | Downloads the release zip and uploads it to CWS via `chrome-webstore-upload-cli`. Upload-only by default; check the `publish` input to also submit for review. |
+| Publish to Chrome Web Store | `publish-cws.yml` | Manual (Actions tab) | Downloads the release zip and uploads it to CWS via the **API v2** with service-account auth, gated behind the `chrome-web-store` environment. Upload-only by default; check the `publish` input to also submit for review. |
 
 ## Release flow
 
@@ -23,13 +23,23 @@ This pipeline shape is shared across navbytes browser-extension repos
    with the store zip attached.
 4. When ready, run **Publish to Chrome Web Store** from the Actions tab.
 
-## Required secrets (publish only)
+## Publish setup (one-time)
 
-`CHROME_EXTENSION_ID`, `CHROME_CLIENT_ID`, `CHROME_CLIENT_SECRET`,
-`CHROME_REFRESH_TOKEN` — see the
-[chrome-webstore-upload-cli setup guide](https://github.com/fregante/chrome-webstore-upload-cli#setup).
-This auth flow (CWS API v1) is deprecated by Google with support ending
-**2026-10-15**; plan a migration to API v2 / service-account auth.
+Publishing uses the [Chrome Web Store API v2 with a service
+account](https://developer.chrome.com/docs/webstore/service-accounts)
+(the v1 OAuth refresh-token flow is deprecated; support ends 2026-10-15):
+
+1. In Google Cloud Console, create a service account (no GCP roles needed)
+   and download a JSON key.
+2. In the CWS Developer Dashboard, add the service account's email under
+   Account → API access, and note your publisher ID.
+3. Create a GitHub environment named `chrome-web-store`
+   (Settings → Environments) with yourself as a **required reviewer**, and
+   add these environment secrets: `CWS_SERVICE_ACCOUNT_JSON` (key file
+   contents), `CHROME_PUBLISHER_ID`, `CHROME_EXTENSION_ID`.
+
+The required-reviewer gate means store credentials are only readable after
+a manual approval click on each publish run.
 
 ## Known limitation
 

--- a/.github/workflows/publish-cws.yml
+++ b/.github/workflows/publish-cws.yml
@@ -4,10 +4,22 @@ name: Publish to Chrome Web Store
 # to the Chrome Web Store is a human decision. Trigger this from the
 # Actions tab once a GitHub Release exists.
 #
-# NOTE: the CWS API v1 auth flow these secrets use (OAuth client id/secret +
-# refresh token) is deprecated by Google and supported only until
-# 2026-10-15. Migrate to a tool with API v2 / service-account support
-# before then.
+# Uses the Chrome Web Store API v2 with service-account auth (the v1
+# OAuth refresh-token flow is deprecated; support ends 2026-10-15).
+#
+# One-time setup:
+#   1. In Google Cloud Console, create a service account (no GCP roles
+#      needed) and download a JSON key for it.
+#   2. In the Chrome Web Store Developer Dashboard, add the service
+#      account's email under Account → API access, and note your
+#      publisher ID. See:
+#      https://developer.chrome.com/docs/webstore/service-accounts
+#   3. Create a GitHub environment named `chrome-web-store` (Settings →
+#      Environments), add yourself as a required reviewer, and add these
+#      environment secrets:
+#        CWS_SERVICE_ACCOUNT_JSON — contents of the JSON key file
+#        CHROME_PUBLISHER_ID      — publisher ID from the dashboard
+#        CHROME_EXTENSION_ID      — the extension's ID
 on:
   workflow_dispatch:
     inputs:
@@ -33,17 +45,19 @@ jobs:
     name: Upload release zip to the store
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Store credentials live as environment secrets gated by a required
+    # reviewer, so nothing can read them without a manual approval click.
+    environment: chrome-web-store
     steps:
       - name: Verify Chrome Web Store credentials
         run: |
           missing=""
+          [ -z "${{ secrets.CWS_SERVICE_ACCOUNT_JSON }}" ] && missing="$missing CWS_SERVICE_ACCOUNT_JSON"
+          [ -z "${{ secrets.CHROME_PUBLISHER_ID }}" ] && missing="$missing CHROME_PUBLISHER_ID"
           [ -z "${{ secrets.CHROME_EXTENSION_ID }}" ] && missing="$missing CHROME_EXTENSION_ID"
-          [ -z "${{ secrets.CHROME_CLIENT_ID }}" ] && missing="$missing CHROME_CLIENT_ID"
-          [ -z "${{ secrets.CHROME_CLIENT_SECRET }}" ] && missing="$missing CHROME_CLIENT_SECRET"
-          [ -z "${{ secrets.CHROME_REFRESH_TOKEN }}" ] && missing="$missing CHROME_REFRESH_TOKEN"
           if [ -n "$missing" ]; then
-            echo "Missing repository secrets:$missing"
-            echo "See https://github.com/fregante/chrome-webstore-upload-cli#setup"
+            echo "Missing environment secrets:$missing"
+            echo "See the setup comment at the top of this workflow file."
             exit 1
           fi
 
@@ -69,22 +83,50 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Authenticate service account
+        id: auth
+        uses: google-github-actions/auth@v3
         with:
-          bun-version-file: .bun-version
+          credentials_json: ${{ secrets.CWS_SERVICE_ACCOUNT_JSON }}
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/chromewebstore
 
-      # Default is upload-only (a draft you submit from the CWS dashboard);
-      # check the "publish" input to also submit for review automatically.
+      # Upload creates a new draft; the publish call additionally submits
+      # it for review. Both via the v2 REST API — no third-party CLI yet
+      # supports v2, and it's two curl calls.
       - name: Upload to Chrome Web Store
-        run: |
-          if [ "${{ inputs.publish }}" = "true" ]; then
-            bunx chrome-webstore-upload-cli@4 upload --source Pacify_*.zip --auto-publish
-          else
-            bunx chrome-webstore-upload-cli@4 upload --source Pacify_*.zip
-          fi
         env:
+          TOKEN: ${{ steps.auth.outputs.access_token }}
+          PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
           EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
-          CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
-          CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
-          REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+        run: |
+          FILE=$(ls Pacify_*.zip)
+          echo "Uploading $FILE"
+          HTTP_CODE=$(curl -sS -o upload-response.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -T "$FILE" \
+            "https://chromewebstore.googleapis.com/upload/v2/publishers/$PUBLISHER_ID/items/$EXTENSION_ID:upload")
+          cat upload-response.json; echo
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "Upload failed with HTTP $HTTP_CODE"
+            exit 1
+          fi
+          echo "Upload succeeded (HTTP $HTTP_CODE)"
+
+      - name: Submit for review
+        if: inputs.publish
+        env:
+          TOKEN: ${{ steps.auth.outputs.access_token }}
+          PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
+          EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+        run: |
+          HTTP_CODE=$(curl -sS -o publish-response.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Length: 0" \
+            "https://chromewebstore.googleapis.com/v2/publishers/$PUBLISHER_ID/items/$EXTENSION_ID:publish")
+          cat publish-response.json; echo
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "Publish failed with HTTP $HTTP_CODE"
+            exit 1
+          fi
+          echo "Submitted for review (HTTP $HTTP_CODE)"


### PR DESCRIPTION
## Summary

Follow-up to #47: future-proofs Chrome Web Store publishing before Google's v1 API shutdown and adds environment gating for the store credentials.

## Changes

**`publish-cws.yml`**
- **CWS API v2 + service-account auth** replaces the deprecated v1 OAuth refresh-token flow (v1 support ends **2026-10-15**). `google-github-actions/auth@v3` exchanges a service-account JSON key for a `chromewebstore`-scoped access token; upload and publish are direct calls to the v2 REST endpoints (`…:upload` / `…:publish`) — no third-party CLI or action supports v2 yet, and it's two curl calls.
- **Environment gating**: the job now runs in a `chrome-web-store` GitHub environment. With a required reviewer configured, credentials are only readable after a manual approval click on each run.
- Same behavior as before: manual trigger, upload-as-draft by default, optional `publish` input to submit for review.

**`workflows/README.md`** — documents the new one-time setup.

## Required one-time setup (after merge)

1. Google Cloud Console → create a service account (no GCP roles needed) → download a JSON key.
2. CWS Developer Dashboard → Account → API access → add the service account's email; note your publisher ID. ([docs](https://developer.chrome.com/docs/webstore/service-accounts))
3. GitHub → Settings → Environments → create `chrome-web-store`, add yourself as a **required reviewer**, and add environment secrets `CWS_SERVICE_ACCOUNT_JSON`, `CHROME_PUBLISHER_ID`, `CHROME_EXTENSION_ID`.

The old `CHROME_CLIENT_ID` / `CHROME_CLIENT_SECRET` / `CHROME_REFRESH_TOKEN` secrets are no longer used and can be deleted (if they were ever added).

https://claude.ai/code/session_01JXt6DydohimQa4nkAN2sxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXt6DydohimQa4nkAN2sxr)_