### PR TITLE
fix: support non-ASCII (e.g. Chinese) comments in PAC scripts

### DIFF
--- a/src/utils/__tests__/chrome.test.ts
+++ b/src/utils/__tests__/chrome.test.ts
@@ -33,6 +33,50 @@ describe('convertAppSettingsToChromeConfig', () => {
     expect(result.pacScript).toEqual({ url: 'https://x/p.pac', data: '', mandatory: true })
   })
 
+  test('ASCII-only inline pac_script is passed through unchanged via data', () => {
+    const data = 'function FindProxyForURL(url, host) { return "DIRECT"; }'
+    const result = convertAppSettingsToChromeConfig(
+      cfg({ mode: 'pac_script', pacScript: { data } })
+    )
+    expect(result.pacScript).toEqual({ url: '', data, mandatory: false })
+  })
+
+  // Regression: Chrome converts pacScript.data into a charset-less data: URL
+  // and decodes it as Latin-1, corrupting non-ASCII (e.g. Chinese) comments.
+  // We must encode it ourselves as a UTF-8 data: URL routed through `url`.
+  test('inline pac_script with Chinese comments is encoded as a UTF-8 data: URL', () => {
+    const data = `function FindProxyForURL(url, host) {
+  // 走代理服务器
+  return "PROXY 127.0.0.1:8080";
+}`
+    const result = convertAppSettingsToChromeConfig(
+      cfg({ mode: 'pac_script', pacScript: { data, mandatory: true } })
+    )
+
+    expect(result.pacScript?.data).toBe('')
+    expect(result.pacScript?.mandatory).toBe(true)
+    const url = result.pacScript?.url ?? ''
+    expect(url.startsWith('data:application/x-ns-proxy-autoconfig;charset=utf-8;base64,')).toBe(
+      true
+    )
+
+    // The base64 payload must round-trip back to the exact original UTF-8 script.
+    const base64 = url.split(',')[1]
+    const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0))
+    const decoded = new TextDecoder().decode(bytes)
+    expect(decoded).toBe(data)
+  })
+
+  test('a real URL always wins over the data: URL encoding path', () => {
+    const result = convertAppSettingsToChromeConfig(
+      cfg({
+        mode: 'pac_script',
+        pacScript: { url: 'https://x/p.pac', data: '// 中文\nfunction FindProxyForURL(){}' },
+      })
+    )
+    expect(result.pacScript?.url).toBe('https://x/p.pac')
+  })
+
   test('fixed_servers with a single shared proxy maps host/port/scheme', () => {
     const result = convertAppSettingsToChromeConfig(
       cfg({ rules: { singleProxy: { scheme: 'socks5', host: '10.0.0.1', port: '1080' } } })

--- a/src/utils/chrome.ts
+++ b/src/utils/chrome.ts
@@ -1,5 +1,38 @@
 import type { ChromeProxyConfig, ProxyConfig } from '@/interfaces'
 
+// Data-URL prefix Chrome uses for inline PAC scripts. We add an explicit
+// `charset=utf-8` (Chrome's own `pacScript.data` handling omits it) so the
+// bytes are decoded as UTF-8 instead of Latin-1.
+const PAC_DATA_URL_PREFIX = 'data:application/x-ns-proxy-autoconfig;charset=utf-8;base64,'
+
+function hasNonAscii(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    if (value.charCodeAt(i) > 0x7f) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Encode an inline PAC script as a base64 `data:` URL with an explicit UTF-8
+ * charset.
+ *
+ * Chrome converts a `pacScript.data` value into a `data:` URL internally, but
+ * it does not declare a charset. The PAC fetcher then defaults to Latin-1, so
+ * any non-ASCII bytes — e.g. Chinese characters in comments — are mis-decoded
+ * and the script can fail to load. Building the URL ourselves with
+ * `charset=utf-8` keeps multi-byte content intact.
+ */
+function encodePacDataUrl(script: string): string {
+  const bytes = new TextEncoder().encode(script)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return PAC_DATA_URL_PREFIX + btoa(binary)
+}
+
 /**
 
 Converts an AppSettings object to a Chrome proxy configuration object.
@@ -19,10 +52,23 @@ export function convertAppSettingsToChromeConfig(proxyConfig: ProxyConfig): Chro
 
   // For pac_script mode, include the pacScript details.
   if (proxyConfig.mode === 'pac_script' && proxyConfig.pacScript) {
-    result.pacScript = {
-      url: proxyConfig.pacScript.url || '',
-      data: proxyConfig.pacScript.data || '',
-      mandatory: proxyConfig.pacScript.mandatory || false,
+    const url = proxyConfig.pacScript.url || ''
+    const data = proxyConfig.pacScript.data || ''
+    const mandatory = proxyConfig.pacScript.mandatory || false
+
+    // Inline scripts containing non-ASCII characters (e.g. Chinese comments)
+    // must be handed to Chrome as a UTF-8 `data:` URL. Chrome's own
+    // `pacScript.data` path produces a charset-less data URL that gets decoded
+    // as Latin-1, corrupting the script. Routing through `url` with an explicit
+    // charset avoids that. ASCII-only scripts keep the original `data` path.
+    if (!url && data && hasNonAscii(data)) {
+      result.pacScript = {
+        url: encodePacDataUrl(data),
+        data: '',
+        mandatory,
+      }
+    } else {
+      result.pacScript = { url, data, mandatory }
     }
   }
   // For fixed_servers mode, include the proxy rules.


### PR DESCRIPTION
## Problem

A store reviewer reported "PAC脚本不支持中文注释" (PAC scripts don't support Chinese comments). PAC scripts containing Chinese — or any non-ASCII — characters fail to load.

This is a Chrome quirk, not a validation issue. PACify's own validation and the CodeMirror editor accept Chinese fine. The break happens at apply time: inline scripts were handed to `chrome.proxy.settings.set` via `pacScript.data`. Chrome converts that into a `data:application/x-ns-proxy-autoconfig;base64,…` URL **without a charset**, so its PAC fetcher decodes the bytes as Latin-1 — corrupting UTF-8 multi-byte sequences and breaking the script.

## Fix

In `convertAppSettingsToChromeConfig` (the single chokepoint every proxy application flows through, including auto-proxy generated scripts whose embedded `// Subscription: …` comments may carry Chinese names):

- Inline scripts containing non-ASCII characters are now encoded by PACify itself as a `data:application/x-ns-proxy-autoconfig;charset=utf-8;base64,<utf8>` URL routed through `pacScript.url`. The explicit charset preserves the UTF-8 bytes.
- ASCII-only inline scripts and URL-sourced configs keep their existing behavior unchanged.

Storage still holds the raw script, so it round-trips and displays normally in the editor — encoding happens only at apply time.

## Tests

Added coverage in `chrome.test.ts`: ASCII passthrough, Chinese-comment encoding with a base64 round-trip assertion, and real-URL precedence.

- Full unit suite: 420 pass / 0 fail
- `svelte-check`: 0 errors
- Biome: clean

https://claude.ai/code/session_01NdeApYh1sjSZJGvo3kBr1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdeApYh1sjSZJGvo3kBr1q)_