### PR TITLE
fix(a11y): re-enable Biome 2.5 a11y rules and address findings

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -37,11 +37,7 @@
         "noLabelWithoutControl": "off",
         "useSemanticElements": "off",
         "useValidAriaValues": "off",
-        "useValidAriaRole": "off",
-        "noStaticElementInteractions": "off",
-        "noSvgWithoutTitle": "off",
-        "useAriaPropsSupportedByRole": "off",
-        "useValidAnchor": "off"
+        "useValidAriaRole": "off"
       },
       "style": {
         "noUnusedTemplateLiteral": "error",

--- a/src/components/Button.svelte
+++ b/src/components/Button.svelte
@@ -146,6 +146,7 @@ const combinedClasses = $derived(
 )
 </script>
 
+<!-- biome-ignore lint/a11y/useAriaPropsSupportedByRole: aria-selected is forwarded only by callers that render this generic Button as role=option/tab; Svelte omits the attribute when ariaSelected is undefined -->
 <button
   {type}
   class={cn(combinedClasses, 'group')}

--- a/src/components/LinkCard.svelte
+++ b/src/components/LinkCard.svelte
@@ -38,6 +38,7 @@ const gradientMap = {
 }
 </script>
 
+<!-- biome-ignore lint/a11y/useValidAnchor: href is provided via Svelte's {href} attribute shorthand (which Biome's own formatter enforces over href={href}); the linter just doesn't recognize the shorthand as a href attribute -->
 <a {href} {target} {rel} class="group block">
   <div
     class="relative overflow-hidden rounded-xl transition-all duration-300 hover:scale-[1.02] hover:shadow-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800"

--- a/src/components/ProxyConfig/ConnectionTypeSelect.svelte
+++ b/src/components/ProxyConfig/ConnectionTypeSelect.svelte
@@ -118,6 +118,7 @@ function onMenuKeydown(event: KeyboardEvent) {
 }
 </script>
 
+<!-- biome-ignore lint/a11y/noStaticElementInteractions: window-level outside-click handler to dismiss the dropdown; there is no semantic element equivalent for a global listener -->
 <svelte:window
   onclick={(e) => {
     if (isOpen && !(e.target as HTMLElement)?.closest('[data-conn-type]')) isOpen = false

--- a/src/components/ProxyConfig/ProxyConfigModal.svelte
+++ b/src/components/ProxyConfig/ProxyConfigModal.svelte
@@ -460,6 +460,7 @@ function handleBackdropClick(event: MouseEvent) {
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
+                aria-hidden="true"
               >
                 <path
                   stroke-linecap="round"
@@ -516,7 +517,7 @@ function handleBackdropClick(event: MouseEvent) {
           >
             {#snippet icon()}
               {#if isSubmitting}
-                <svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24">
+                <svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24" aria-hidden="true">
                   <circle
                     class="opacity-25"
                     cx="12"

--- a/src/components/ProxyConfig/ProxyInput.svelte
+++ b/src/components/ProxyConfig/ProxyInput.svelte
@@ -186,6 +186,7 @@ $effect(() => {
         fill="none"
         stroke="currentColor"
         viewBox="0 0 24 24"
+        aria-hidden="true"
       >
         <path
           stroke-linecap="round"

--- a/src/components/ScriptItem.svelte
+++ b/src/components/ScriptItem.svelte
@@ -232,6 +232,7 @@ async function handleScriptDelete() {
               style={proxy.isActive
               ? `background-color: ${proxy.color}; ring-color: ${proxy.color}40`
               : `background-color: ${proxy.color}`}
+              role="img"
               aria-label="Proxy color: {proxy.color}"
             ></div>
           </div>

--- a/src/components/Tooltip.svelte
+++ b/src/components/Tooltip.svelte
@@ -29,6 +29,7 @@ function handleMouseLeave() {
 }
 </script>
 
+<!-- biome-ignore lint/a11y/noStaticElementInteractions: presentational hover/focus positioner for the tooltip; the interactive trigger is the slotted child -->
 <div
   role="presentation"
   class="relative inline-block"


### PR DESCRIPTION
Follow-up to #49, which temporarily scoped **8** a11y rules off in `biome.json` because Biome 2.5's Svelte support flagged ~60 findings — most of them false positives on valid, accessible code. This PR works through every finding and **re-enables the 4 rules that have genuine, fixable issues**, documenting precisely why the other 4 can't be turned back on yet.

## ✅ Re-enabled (4 rules)

| Rule | Fix |
|---|---|
| `noSvgWithoutTitle` | `aria-hidden="true"` on 3 decorative SVG icons (ProxyConfigModal ×2, ProxyInput) |
| `useAriaPropsSupportedByRole` | `role="img"` on ScriptItem's color-dot (legitimizes its `aria-label`); justified ignore on the generic `Button` (forwards `aria-selected` only when a caller renders it as `role=option/tab`) |
| `useValidAnchor` | justified ignore on `LinkCard` — `href` **is** provided via Svelte's `{href}` shorthand, which Biome's own *formatter* rewrites `href={href}` into, but its *linter* then rejects |
| `noStaticElementInteractions` | justified ignores on the window outside-click listener (ConnectionTypeSelect) and the Tooltip's presentational hover/focus wrapper — neither has a semantic-element equivalent |

## ⛔ Kept off (proven false positives)

Each was tested, not assumed:

- **`noLabelWithoutControl` (28)** — valid `<label for=X>` ↔ `<Control id=X>` associations *across components* + `{i18n}` label text Biome can't read. The `inputComponents` rule option only helps *nested* controls, not sibling/cross-component `for`/`id`.
- **`useValidAriaValues` (10) / `useValidAriaRole` (1)** — dynamic ARIA bindings (`aria-expanded={isOpen}`, toast `role={…}`). Biome demands a *static literal*; `{x}`, `{x ? true : false}`, `{x ? 'true' : 'false'}`, and a `boolean` type annotation all fail. Removing the attribute would break screen-reader support.
- **`useSemanticElements` (14)** — intentional `role="list/listitem/region/radio/button"` on styled elements. Native conversion is **cosmetic only** (identical assistive-tech semantics) at real markup/behavior risk on shipped UI. Happy to convert the clean `role="list"→<ul>` / `role="region"→<section>` cases in a follow-up if you'd prefer the native markup.

## Verification
`bun run check:ci` clean · `svelte-check` 0 errors / 0 warnings · `bun run build` ok · **552 unit tests pass**

These 4 rules should be revisited whenever Biome improves its Svelte analysis.