### PR TITLE
fix: prevent infinite loop when sync storage read fails

### DIFF
--- a/src/components/AutoProxy/AutoProxyModal.svelte
+++ b/src/components/AutoProxy/AutoProxyModal.svelte
@@ -502,7 +502,7 @@ let selectableProxies = $derived(
 
       <!-- Error Message -->
       {#if errorMessage}
-        <div class={redSection.wrapper()} data-error-message>
+        <div class={redSection.wrapper()} data-error-message role="alert">
           <div class={redSection.background()}></div>
           <div class={redSection.accentBar()}></div>
           <div class="relative p-4 {redSection.content()}">

--- a/src/components/ImportModal.svelte
+++ b/src/components/ImportModal.svelte
@@ -411,7 +411,7 @@ let skippedCount = $derived(warnings.filter((w) => w.level === 'skipped').length
       {/if}
 
       {#if errorMessage}
-        <div class="mt-3 rounded-md bg-red-50 dark:bg-red-950/30 p-3">
+        <div class="mt-3 rounded-md bg-red-50 dark:bg-red-950/30 p-3" role="alert">
           <Text as="p" size="sm" classes="text-red-700 dark:text-red-300">{errorMessage}</Text>
         </div>
       {/if}

--- a/src/options/ProxyConfigsTab.svelte
+++ b/src/options/ProxyConfigsTab.svelte
@@ -255,7 +255,10 @@ async function handleViewModeChange(mode: ViewMode) {
   </div>
 
   {#if dropError}
-    <div class="mb-6 rounded-md bg-red-100 p-4 text-red-700 dark:bg-red-900/50 dark:text-red-200">
+    <div
+      class="mb-6 rounded-md bg-red-100 p-4 text-red-700 dark:bg-red-900/50 dark:text-red-200"
+      role="alert"
+    >
       <Text as="p">{dropError}</Text>
     </div>
   {/if}

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -3,7 +3,6 @@ import { ALERT_TYPES } from '@/interfaces/error'
 import { type ToastType, toastStore } from '@/stores/toastStore'
 import { browserService } from './chrome/BrowserService'
 import { I18nService } from './i18n/i18nService'
-import { StorageService } from './StorageService'
 
 /**
  * Notification context determines where notifications are shown
@@ -39,8 +38,13 @@ export class NotificationService {
    */
   private static async areNotificationsEnabled(): Promise<boolean> {
     try {
-      const preferences = await StorageService.getPreferences()
-      return preferences?.notifications ?? true
+      // Read storage directly rather than via StorageService.getPreferences():
+      // that accessor is wrapped in withErrorHandlingAndFallback, whose catch
+      // calls NotificationService.error() -> show() -> back here, so a failing
+      // read would loop forever. The raw call throws, so the catch below works.
+      const data = await browserService.storage.sync.get('preferences')
+      const stored = data.preferences as { notifications?: boolean } | undefined
+      return stored?.notifications ?? true
     } catch {
       return true // Fallback to enabled if we can't read settings
     }

--- a/src/services/__tests__/NotificationService.test.ts
+++ b/src/services/__tests__/NotificationService.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, spyOn, test } from 'bun:test'
+import { browserService } from '@/services/chrome/BrowserService'
+import { StorageService } from '@/services/StorageService'
+
+/**
+ * Guards the NotificationService -> StorageService -> errorHandling cycle.
+ *
+ * StorageService.getPreferences is wrapped in withErrorHandlingAndFallback,
+ * whose catch calls NotificationService.error(). If NotificationService reads
+ * preferences back through that same wrapped accessor, a storage failure makes
+ * the two call each other forever. Reported by a graph import-cycle analysis.
+ */
+describe('NotificationService / StorageService cycle', () => {
+  test('a sync-storage failure falls back once instead of recursing', async () => {
+    const get = spyOn(browserService.storage.sync, 'get').mockRejectedValue(
+      new Error('QUOTA_BYTES quota exceeded')
+    )
+
+    try {
+      const prefs = await StorageService.getPreferences()
+
+      expect(prefs).toEqual({ notifications: true, loggingEnabled: false })
+      // The recursion assertion. Two reads are correct and terminal: the
+      // original getPreferences, plus NotificationService checking whether
+      // notifications are enabled before reporting the failure. That second
+      // read throws too, but is caught locally instead of re-entering.
+      // Before the fix this count was unbounded and the test hung.
+      expect(get.mock.calls.length).toBeLessThanOrEqual(2)
+    } finally {
+      get.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
## The bug

`NotificationService`, `StorageService` and `errorHandling` formed an import cycle. It wasn't cosmetic — it turned any `chrome.storage.sync` failure into an unbounded loop:

```
StorageService.getPreferences   (wrapped in withErrorHandlingAndFallback)
  └─> catch calls NotificationService.error()
        └─> show() calls areNotificationsEnabled()
              └─> StorageService.getPreferences() fails again
                    └─> back to the catch ...
```

`areNotificationsEnabled` *had* a `try/catch`, but it sat on the wrong side of the wrapper: `withErrorHandlingAndFallback` never rethrows — it returns the fallback — so the guard never fired.

Because every hop `await`s, this is a microtask loop rather than a stack overflow: **the service worker spins forever instead of crashing.** A test that rejects `storage.sync.get` hung for the full 2-minute timeout before this change.

Reachable whenever `storage.sync` fails — quota exceeded, invalidated extension context. Given #79 shipped chunking specifically to work around sync quota pressure, this isn't a hypothetical path.

## The fix

Read storage directly in `areNotificationsEnabled` instead of going through the error-wrapped accessor. The raw call throws, so the existing `catch` becomes functional, and dropping the `StorageService` import breaks the cycle at its source.

Verified with the graph analysis that surfaced it — it now reports `Import Cycles: None detected.`

The new test asserts the read count is *bounded* (≤2), not exactly 1: two reads is correct and terminal — the original `getPreferences`, plus `NotificationService` legitimately checking whether notifications are enabled before reporting the failure. That second read also throws, but is now caught locally instead of re-entering. Before the fix the count was unbounded.

## Also included

`role="alert"` on three error regions that rendered silently to screen readers (`ImportModal`, `AutoProxyModal`, `ProxyConfigsTab`) — part of the still-outstanding **E8** finding in `ux-review/02-heuristic-eval.md`. One attribute each, no behavioural change.

## Verification

- 595 unit tests pass (`bun run test`)
- `svelte-check` — 0 errors, 0 warnings
- `biome check ./src` — clean (2 pre-existing warnings in untouched files)
- E2E not run locally (needs a Chrome build); CI covers it

## Not in this PR

Five **field-level** error regions are still silent (`BasicSettings:97`, `ProxyInput:132/163`, `PACScriptSettings:286`, `SubscriptionList:469`, `FallbackConfig:107`). Those want `aria-invalid` + `aria-describedby` wiring to their inputs rather than `role="alert"` — announcing on every validation keystroke would be worse than silence. Left as a separate change since it carries a UX judgment.