### PR TITLE
ci: hand the release PR back to release-please after tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: write # create the tag + GitHub Release
+      pull-requests: write # hand the release PR back to release-please
+      issues: write # ensure the "autorelease: tagged" label exists
 
     steps:
       - name: Checkout code
@@ -115,6 +117,30 @@ jobs:
           files: Pacify_${{ steps.version.outputs.VERSION }}.zip
           draft: false
           prerelease: false
+
+      # release-please tracks release PRs by label and refuses to open the next
+      # one while a merged release PR is still "autorelease: pending". This repo
+      # sets skip-github-release, so release-please never creates the release and
+      # therefore never flips that label itself — the workflow that does create
+      # the release has to, or the first release silently blocks every one after
+      # it (which is exactly what happened between v1.33.1 and v1.33.2).
+      - name: Hand the release PR back to release-please
+        if: steps.guard.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create "autorelease: tagged" --repo "$GITHUB_REPOSITORY" \
+            --color ededed --description "Release PR has been tagged" --force >/dev/null
+          prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --state merged \
+            --label "autorelease: pending" --json number --jq '.[].number')
+          if [ -z "$prs" ]; then
+            echo "No pending release PR to mark."
+          fi
+          for pr in $prs; do
+            echo "Marking PR #$pr as tagged"
+            gh pr edit "$pr" --repo "$GITHUB_REPOSITORY" \
+              --add-label "autorelease: tagged" --remove-label "autorelease: pending"
+          done
 
       # Chrome Web Store submission is deliberately NOT part of this
       # workflow — it is a manual, human-triggered step. Run the


### PR DESCRIPTION
Releases have been silently blocked since **v1.33.1 (3 July)**. Every release-please run since then aborts with:

> ⚠ There are untagged, merged release PRs outstanding - aborting

## Cause

release-please tracks release PRs with a label: `autorelease: pending` while unreleased, `autorelease: tagged` once released. It flips that label **when it creates the GitHub release**.

This repo sets `skip-github-release: true` — release-please deliberately doesn't create the release, `release.yml` does. But nothing ever flipped the label, so PR #56 is still `autorelease: pending` and release-please refuses to open the next release PR.

So the *first* release under this arrangement blocked every release after it. `fix:` commits from #79 and #82 have been sitting unreleased.

## Fix

`release.yml` now flips the label after it has created the tag and release — the handoff that was missing. Without this it recurs after every release.

Also adds the `pull-requests: write` and `issues: write` permissions that step needs.

Verified: YAML parses, the job's step order is unchanged apart from the new step sitting between "Create GitHub Release" and the store-publish note. Chrome Web Store publishing remains manual and untouched.