### PR TITLE
fix(popup): keep "No proxy (direct)" reachable without scrolling

### DIFF
--- a/src/popup/Popup.svelte
+++ b/src/popup/Popup.svelte
@@ -100,7 +100,7 @@ function onRadioKeydown(event: KeyboardEvent) {
   </header>
 
   <!-- Main Content -->
-  <main class="popup-scroll overflow-y-auto flex-1 px-5 pt-4 pb-4">
+  <main class="popup-scroll overflow-y-auto flex-1 px-5 pt-4">
     {#if hasProxies}
       <!-- Active-status hero: the proxy state, glanceable at the top, never
            scrolled off below the list (J1). -->
@@ -183,34 +183,43 @@ function onRadioKeydown(event: KeyboardEvent) {
           </button>
         {/each}
 
-        <!-- "No proxy (direct)" is the off state — one control for on/off/switch -->
-        <button
-          type="button"
-          role="radio"
-          aria-checked={!activeProxy}
-          tabindex={!activeProxy ? 0 : -1}
-          data-testid="popup-direct-row"
-          onclick={goDirect}
-          onkeydown={onRadioKeydown}
-          class={cn(
+        <!-- "No proxy (direct)" is the off state — one control for on/off/switch.
+             Pinned to the bottom of the scroll area: with a handful of proxies
+             it sat below the fold (274px past it at 7), so the single most
+             common "get me back to normal" action needed a scroll. Sticky keeps
+             DOM order, so arrow keys still read proxies-then-off, and the row
+             holds one screen position for muscle memory. -->
+        <div
+          class="sticky bottom-0 -mx-5 mt-1 flex flex-col border-t border-slate-200 bg-white px-5 pt-2 pb-4 dark:border-slate-700 dark:bg-slate-900"
+        >
+          <button
+            type="button"
+            role="radio"
+            aria-checked={!activeProxy}
+            tabindex={!activeProxy ? 0 : -1}
+            data-testid="popup-direct-row"
+            onclick={goDirect}
+            onkeydown={onRadioKeydown}
+            class={cn(
             'relative flex items-center gap-3 rounded-xl border px-3 py-2.5 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500',
             !activeProxy
               ? 'border-transparent ring-2 ring-blue-500 bg-blue-50/50 dark:bg-blue-950/20'
               : 'border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600'
           )}
-        >
-          <span
-            class="w-3 h-3 rounded-full shrink-0 bg-slate-300 dark:bg-slate-600 border border-black/5"
-          ></span>
-          <span class="min-w-0 flex-1">
-            <span class="block text-sm font-semibold truncate text-slate-700 dark:text-slate-200">
-              {I18nService.getMessage('noProxyDirect')}
+          >
+            <span
+              class="w-3 h-3 rounded-full shrink-0 bg-slate-300 dark:bg-slate-600 border border-black/5"
+            ></span>
+            <span class="min-w-0 flex-1">
+              <span class="block text-sm font-semibold truncate text-slate-700 dark:text-slate-200">
+                {I18nService.getMessage('noProxyDirect')}
+              </span>
+              <span class="block text-xs truncate text-slate-500 dark:text-slate-400">
+                {I18nService.getMessage('noProxyDirectHint')}
+              </span>
             </span>
-            <span class="block text-xs truncate text-slate-500 dark:text-slate-400">
-              {I18nService.getMessage('noProxyDirectHint')}
-            </span>
-          </span>
-        </button>
+          </button>
+        </div>
       </div>
     {:else}
       <EmptyState


### PR DESCRIPTION
Turning the proxy off was the hardest thing to do in the popup, and it got harder the more proxies you had.

"No proxy (direct)" is the last row of a scrolling list. Measured in a 400px popup with seven proxies: the row sat at **674px — 274px below the fold**, with 298px of the list hidden. It's the most common "get me back to normal" action and the only one that needed a scroll.

## Pinned, not moved to the top

Moving it to the top fixes visibility, but it pushes the user's actual proxies down and spends the first slot on the least interesting row.

Pinning to the bottom gets the visibility *and*:
- keeps the "here are your proxies… or turn it off" reading order
- holds one constant screen position whatever the list length (muscle memory)
- leaves DOM order alone, so arrow keys and the roving `tabindex` are unchanged

`main`'s bottom padding moves onto the pinned row so it sits flush with the scrollport — otherwise a strip of scrolled content showed beneath it.

## Not a separate "turn off" button

That was already settled in `ux-review/04-wave2-mockups.md`:

> **One control, not two.** Remove the master On/Off segment; the "No proxy (direct)" row is the off state.

Pinning respects that — still one control, just always reachable.

## Verification

Reachable without scrolling: **false → true** (674px → 389px in a 400px popup).

Edge cases checked visually: with two proxies the divider reads as a section break rather than a floating bar, and when scrolled the list passes cleanly under the pinned row.

595 unit tests, **54/54 e2e including the axe-core accessibility suite** (relevant — this adds a wrapper element inside the `radiogroup`), `svelte-check` 0 errors, biome clean, build OK.