### PR TITLE
fix(proxy): reject proxy configs Chrome cannot apply

### DIFF
--- a/src/components/ProxyConfig/ProxyConfigModal.svelte
+++ b/src/components/ProxyConfig/ProxyConfigModal.svelte
@@ -7,6 +7,7 @@ import { I18nService } from '@/services/i18n/i18nService'
 import { logger } from '@/services/LoggerService'
 import { SettingsWriter } from '@/services/SettingsWriter'
 import { toastStore } from '@/stores/toastStore'
+import { toChromeProxyServer } from '@/utils/chrome'
 import { flexPatterns, modalVariants } from '@/utils/classPatterns'
 import { cn } from '@/utils/cn'
 import { getRandomProxyColor } from '@/utils/colors'
@@ -205,14 +206,7 @@ async function handleSubmit(event: Event) {
       }
 
       if (useSharedProxy) {
-        // For single proxy, we need to ensure the proxy has at least a host
-        if (proxySettings.singleProxy?.host?.trim()) {
-          config.rules.singleProxy = proxySettings.singleProxy
-        } else {
-          // If no host is provided, but we're in fixed_servers mode with useSharedProxy,
-          // we still need to save the configuration (it might be intentionally empty)
-          config.rules.singleProxy = proxySettings.singleProxy
-        }
+        config.rules.singleProxy = proxySettings.singleProxy
       } else {
         // For individual proxies, add only those with hosts
         if (proxySettings.proxyForHttp?.host?.trim())
@@ -223,6 +217,29 @@ async function handleSubmit(event: Event) {
           config.rules.proxyForFtp = proxySettings.proxyForFtp
         if (proxySettings.fallbackProxy?.host?.trim())
           config.rules.fallbackProxy = proxySettings.fallbackProxy
+      }
+
+      // A fixed_servers config with no fully-specified server cannot be
+      // applied: Chrome rejects the whole payload and silently keeps the
+      // previous setting, so the UI would show the proxy as active while
+      // traffic went out unproxied. toChromeProxyServer is the same predicate
+      // the Chrome boundary uses, so the form and the apply step agree.
+      const usable = [
+        config.rules.singleProxy,
+        config.rules.proxyForHttp,
+        config.rules.proxyForHttps,
+        config.rules.proxyForFtp,
+        config.rules.fallbackProxy,
+      ].some((server) => toChromeProxyServer(server) !== null)
+
+      if (!usable) {
+        errorMessage = I18nService.getMessage('invalidProxyPort')
+        tick().then(() => {
+          document
+            .querySelector('[data-error-message]')
+            ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        })
+        return
       }
     }
 

--- a/src/interfaces/settings.ts
+++ b/src/interfaces/settings.ts
@@ -113,6 +113,29 @@ export interface ProxySettings {
 
 export type ProxyType = keyof Omit<ProxySettings, 'bypassList'>
 
+/**
+ * The proxy payload as Chrome's API actually expects it.
+ *
+ * Deliberately NOT the app's `ProxyServer`/`ProxyRules`: those model what the
+ * settings form produces and what we persist, where `port` is the string an
+ * `<input>` yields. Chrome wants a number. Reusing one type for both contracts
+ * is what let an unconvertible `port: ''` reach chrome.proxy.settings.set().
+ */
+export interface ChromeProxyServer {
+  scheme: ProxyScheme
+  host: string
+  port: number
+}
+
+export interface ChromeProxyRules {
+  singleProxy?: ChromeProxyServer
+  proxyForHttp?: ChromeProxyServer
+  proxyForHttps?: ChromeProxyServer
+  proxyForFtp?: ChromeProxyServer
+  fallbackProxy?: ChromeProxyServer
+  bypassList?: string[]
+}
+
 export interface ChromeProxyConfig {
   mode: ProxyMode
   pacScript?: {
@@ -122,5 +145,5 @@ export interface ChromeProxyConfig {
     updateInterval?: number
     lastFetched?: number
   }
-  rules?: ProxyRules
+  rules?: ChromeProxyRules
 }

--- a/src/services/chrome/ChromeService.ts
+++ b/src/services/chrome/ChromeService.ts
@@ -22,15 +22,7 @@ export class ChromeService {
         value: convertAppSettingsToChromeConfig(proxy),
         scope: 'regular',
       }
-      // ChromeProxyConfig types `port` as a string (that is what the settings
-      // UI stores and what Chrome accepts — the e2e proxy-routing tests cover
-      // it), while @types/chrome declares ProxyServer.port as a number. The
-      // cast records that mismatch instead of hiding it; the previous
-      // BrowserService wrapper typed this parameter as `unknown`, which
-      // silently erased all type checking on the proxy config.
-      await chrome.proxy.settings.set(
-        details as unknown as chrome.types.ChromeSettingSetDetails<chrome.proxy.ProxyConfig>
-      )
+      await chrome.proxy.settings.set(details)
 
       // Reload active tab to apply proxy changes if enabled
       if (autoReload) {

--- a/src/services/import/detectCurrentProxy.ts
+++ b/src/services/import/detectCurrentProxy.ts
@@ -1,5 +1,6 @@
 import type { ChromeProxyConfig, ProxyConfig, ProxyMode } from '@/interfaces'
 import { ChromeService } from '@/services/chrome/ChromeService'
+import { fromChromeProxyRules } from '@/utils/chrome'
 import type { ImportResult, ImportWarning } from './types'
 import { pickColor } from './utils'
 
@@ -55,7 +56,7 @@ export async function detectCurrentProxy(): Promise<ImportResult> {
       data: value.pacScript.data || undefined,
     }
   } else if (mode === 'fixed_servers' && value.rules) {
-    config.rules = value.rules
+    config.rules = fromChromeProxyRules(value.rules)
   }
 
   if (mode === 'direct') {

--- a/src/utils/__tests__/chrome.test.ts
+++ b/src/utils/__tests__/chrome.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test'
 import type { ProxyConfig } from '@/interfaces'
-import { convertAppSettingsToChromeConfig } from '../chrome'
+import {
+  convertAppSettingsToChromeConfig,
+  fromChromeProxyRules,
+  toChromeProxyServer,
+} from '../chrome'
 
 function cfg(overrides: Partial<ProxyConfig>): ProxyConfig {
   return {
@@ -81,7 +85,7 @@ describe('convertAppSettingsToChromeConfig', () => {
     const result = convertAppSettingsToChromeConfig(
       cfg({ rules: { singleProxy: { scheme: 'socks5', host: '10.0.0.1', port: '1080' } } })
     )
-    expect(result.rules?.singleProxy).toEqual({ scheme: 'socks5', host: '10.0.0.1', port: '1080' })
+    expect(result.rules?.singleProxy).toEqual({ scheme: 'socks5', host: '10.0.0.1', port: 1080 })
   })
 
   // Regression: bypassList used to be applied only in the per-protocol branch,
@@ -109,7 +113,7 @@ describe('convertAppSettingsToChromeConfig', () => {
         },
       })
     )
-    expect(result.rules?.proxyForHttp).toEqual({ scheme: 'http', host: 'p1', port: '80' })
+    expect(result.rules?.proxyForHttp).toEqual({ scheme: 'http', host: 'p1', port: 80 })
     expect(result.rules?.bypassList).toEqual(['intranet'])
   })
 
@@ -118,5 +122,80 @@ describe('convertAppSettingsToChromeConfig', () => {
       cfg({ rules: { singleProxy: { scheme: 'http', host: 'h', port: '1' }, bypassList: [] } })
     )
     expect(result.rules?.bypassList).toBeUndefined()
+  })
+})
+
+describe('toChromeProxyServer', () => {
+  test('parses a valid port to a number', () => {
+    expect(toChromeProxyServer({ scheme: 'http', host: 'h', port: '8080' })).toEqual({
+      scheme: 'http',
+      host: 'h',
+      port: 8080,
+    })
+  })
+
+  test.each([
+    ['empty port', { scheme: 'http', host: 'h', port: '' }],
+    ['blank port', { scheme: 'http', host: 'h', port: '   ' }],
+    ['non-numeric port', { scheme: 'http', host: 'h', port: 'abc' }],
+    ['port 0', { scheme: 'http', host: 'h', port: '0' }],
+    ['port above range', { scheme: 'http', host: 'h', port: '65536' }],
+    ['missing host', { scheme: 'http', host: '', port: '8080' }],
+  ])('rejects %s', (_label, server) => {
+    expect(toChromeProxyServer(server as any)).toBeNull()
+  })
+
+  test('tolerates a numeric port already stored by the detect-current-proxy flow', () => {
+    expect(toChromeProxyServer({ scheme: 'http', host: 'h', port: 8080 } as any)).toEqual({
+      scheme: 'http',
+      host: 'h',
+      port: 8080,
+    })
+  })
+})
+
+describe('fixed_servers guards', () => {
+  // The bug: an empty port used to be forwarded as port:'' , Chrome rejected the
+  // whole config, and the extension reported the proxy as active while traffic
+  // went out unproxied.
+  test('throws instead of emitting a config Chrome will reject', () => {
+    expect(() =>
+      convertAppSettingsToChromeConfig(
+        cfg({ rules: { singleProxy: { scheme: 'http', host: '127.0.0.1', port: '' } } })
+      )
+    ).toThrow(/no usable server/i)
+  })
+
+  test('drops unfilled per-protocol entries instead of forwarding them', () => {
+    const result = convertAppSettingsToChromeConfig(
+      cfg({
+        rules: {
+          proxyForHttp: { scheme: 'http', host: 'p1', port: '80' },
+          proxyForHttps: { scheme: 'http', host: '', port: '' },
+          proxyForFtp: { scheme: 'http', host: '', port: '' },
+        },
+      })
+    )
+    expect(result.rules?.proxyForHttp).toEqual({ scheme: 'http', host: 'p1', port: 80 })
+    expect(result.rules?.proxyForHttps).toBeUndefined()
+    expect(result.rules?.proxyForFtp).toBeUndefined()
+  })
+})
+
+describe('fromChromeProxyRules', () => {
+  test('converts Chrome numeric ports back to the stored string shape', () => {
+    expect(
+      fromChromeProxyRules({
+        singleProxy: { scheme: 'socks5', host: '10.0.0.1', port: 1080 },
+        bypassList: ['x'],
+      })
+    ).toEqual({
+      singleProxy: { scheme: 'socks5', host: '10.0.0.1', port: '1080' },
+      proxyForHttp: undefined,
+      proxyForHttps: undefined,
+      proxyForFtp: undefined,
+      fallbackProxy: undefined,
+      bypassList: ['x'],
+    })
   })
 })

--- a/src/utils/chrome.ts
+++ b/src/utils/chrome.ts
@@ -1,4 +1,11 @@
-import type { ChromeProxyConfig, ProxyConfig } from '@/interfaces'
+import type {
+  ChromeProxyConfig,
+  ChromeProxyRules,
+  ChromeProxyServer,
+  ProxyConfig,
+  ProxyRules,
+  ProxyServer,
+} from '@/interfaces'
 
 // Data-URL prefix Chrome uses for inline PAC scripts. We add an explicit
 // `charset=utf-8` (Chrome's own `pacScript.data` handling omits it) so the
@@ -31,6 +38,49 @@ function encodePacDataUrl(script: string): string {
     binary += String.fromCharCode(bytes[i])
   }
   return PAC_DATA_URL_PREFIX + btoa(binary)
+}
+
+/**
+ * Convert one stored proxy server into Chrome's shape, or `null` if it is not
+ * usable.
+ *
+ * A server is only sent to Chrome when it has both a host and a port that
+ * parses to a valid TCP port. Anything else is dropped: Chrome rejects the
+ * *entire* config if any server is malformed, which previously left the
+ * extension reporting a proxy as active while traffic went out unproxied.
+ */
+export function toChromeProxyServer(server: ProxyServer | undefined): ChromeProxyServer | null {
+  if (!server) return null
+
+  const host = server.host?.trim()
+  if (!host) return null
+
+  const port = Number.parseInt(String(server.port ?? '').trim(), 10)
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return null
+
+  return { scheme: server.scheme || 'http', host, port }
+}
+
+/**
+ * Convert Chrome's proxy rules back into the app's storage shape.
+ *
+ * The inverse of {@link toChromeProxyServer}: Chrome hands back numeric ports,
+ * but the settings form and everything we persist use strings. Assigning
+ * Chrome's rules straight across (as the "import current browser proxy" flow
+ * used to) writes numbers into a field the rest of the app reads as a string.
+ */
+export function fromChromeProxyRules(rules: ChromeProxyRules): ProxyRules {
+  const toApp = (s: ChromeProxyServer | undefined): ProxyServer | undefined =>
+    s ? { scheme: s.scheme, host: s.host, port: String(s.port) } : undefined
+
+  return {
+    singleProxy: toApp(rules.singleProxy),
+    proxyForHttp: toApp(rules.proxyForHttp),
+    proxyForHttps: toApp(rules.proxyForHttps),
+    proxyForFtp: toApp(rules.proxyForFtp),
+    fallbackProxy: toApp(rules.fallbackProxy),
+    bypassList: rules.bypassList,
+  }
 }
 
 /**
@@ -74,41 +124,31 @@ export function convertAppSettingsToChromeConfig(proxyConfig: ProxyConfig): Chro
   // For fixed_servers mode, include the proxy rules.
   else if (proxyConfig.mode === 'fixed_servers' && proxyConfig.rules) {
     result.rules = {}
-    if (proxyConfig.rules.singleProxy) {
-      result.rules.singleProxy = {
-        scheme: proxyConfig.rules.singleProxy.scheme || 'http',
-        host: proxyConfig.rules.singleProxy.host || '',
-        port: proxyConfig.rules.singleProxy.port || '',
-      }
+    const single = toChromeProxyServer(proxyConfig.rules.singleProxy)
+    if (single) {
+      result.rules.singleProxy = single
     } else {
-      // Use the values from activeConfig.rules if available, otherwise fall back to default empty fields.
-      if (proxyConfig.rules.proxyForHttp)
-        result.rules.proxyForHttp = proxyConfig.rules.proxyForHttp || {
-          scheme: 'http',
-          host: '',
-          port: '',
-        }
-      if (proxyConfig.rules.proxyForHttps) {
-        result.rules.proxyForHttps = proxyConfig.rules.proxyForHttps || {
-          scheme: 'http',
-          host: '',
-          port: '',
-        }
+      // Per-protocol servers. Each is included only if fully specified; the
+      // form renders an input group for every protocol, so the unused ones
+      // arrive here empty and must not be forwarded.
+      const perProtocol = {
+        proxyForHttp: toChromeProxyServer(proxyConfig.rules.proxyForHttp),
+        proxyForHttps: toChromeProxyServer(proxyConfig.rules.proxyForHttps),
+        proxyForFtp: toChromeProxyServer(proxyConfig.rules.proxyForFtp),
+        fallbackProxy: toChromeProxyServer(proxyConfig.rules.fallbackProxy),
+      } as const
+      for (const [key, server] of Object.entries(perProtocol)) {
+        if (server) result.rules[key as keyof typeof perProtocol] = server
       }
-      if (proxyConfig.rules.proxyForFtp) {
-        result.rules.proxyForFtp = proxyConfig.rules.proxyForFtp || {
-          scheme: 'http',
-          host: '',
-          port: '',
-        }
-      }
-      if (proxyConfig.rules.fallbackProxy) {
-        result.rules.fallbackProxy = proxyConfig.rules.fallbackProxy || {
-          scheme: 'http',
-          host: '',
-          port: '',
-        }
-      }
+    }
+
+    // No usable server means there is nothing to proxy through. Chrome would
+    // reject the config and quietly leave the previous setting in place, so the
+    // extension would show the proxy as active while traffic went out
+    // unproxied. Throwing surfaces it: setProxy is wrapped in
+    // withErrorHandling, which reports the failure to the user.
+    if (!result.rules.singleProxy && Object.keys(result.rules).length === 0) {
+      throw new Error('This proxy has no usable server. Set a host and a port between 1 and 65535.')
     }
 
     // The bypass list applies to BOTH the single-proxy and per-protocol cases,

--- a/tests/e2e/comprehensive-flows.spec.ts
+++ b/tests/e2e/comprehensive-flows.spec.ts
@@ -137,6 +137,10 @@ test.describe('2. PAC Script Configuration - Full CRUD', () => {
 
     // Fill in all fields
     await page.fill('input#scriptName', 'Complete PAC Test')
+    // Section 2 covers PAC scripts, but the modal opens on "Connect through a
+    // server" (fixed_servers), so the mode has to be selected explicitly.
+    await page.getByTestId('conn-type-trigger').click()
+    await page.getByTestId('segment-pac_script').click()
 
     // Pick a color (native color input, bound via Svelte)
     await setColor(page, '#22c55e')
@@ -163,6 +167,10 @@ test.describe('2. PAC Script Configuration - Full CRUD', () => {
     // Create a proxy first
     await page.getByTestId('add-new-script-btn').click()
     await page.fill('input#scriptName', 'Edit PAC Test')
+    // Section 2 covers PAC scripts, but the modal opens on "Connect through a
+    // server" (fixed_servers), so the mode has to be selected explicitly.
+    await page.getByTestId('conn-type-trigger').click()
+    await page.getByTestId('segment-pac_script').click()
     await page.getByTestId('modal-save-btn').click()
     // Wait for modal to close
     await expect(page.getByTestId('modal-title')).not.toBeVisible()
@@ -190,6 +198,10 @@ test.describe('2. PAC Script Configuration - Full CRUD', () => {
     // Create a proxy
     await page.getByTestId('add-new-script-btn').click()
     await page.fill('input#scriptName', 'Delete PAC Test')
+    // Section 2 covers PAC scripts, but the modal opens on "Connect through a
+    // server" (fixed_servers), so the mode has to be selected explicitly.
+    await page.getByTestId('conn-type-trigger').click()
+    await page.getByTestId('segment-pac_script').click()
     await page.getByTestId('modal-save-btn').click()
     // Wait for modal to close
     await expect(page.getByTestId('modal-title')).not.toBeVisible()
@@ -214,6 +226,10 @@ test.describe('2. PAC Script Configuration - Full CRUD', () => {
       await page.getByTestId('add-new-script-btn').click()
       await expect(page.getByTestId('modal-title')).toBeVisible()
       await page.fill('input#scriptName', name)
+      // Section 2 covers PAC scripts, but the modal opens on "Connect through a
+      // server" (fixed_servers), so the mode has to be selected explicitly.
+      await page.getByTestId('conn-type-trigger').click()
+      await page.getByTestId('segment-pac_script').click()
       await page.getByTestId('modal-save-btn').click()
       // Wait for modal to close before verifying proxy was created
       await expect(page.getByTestId('modal-title')).not.toBeVisible()
@@ -340,6 +356,10 @@ test.describe('4. Proxy Activation & Deactivation', () => {
     await page.getByTestId('add-new-script-btn').click()
     await expect(page.getByTestId('modal-title')).toBeVisible()
     await page.fill('input#scriptName', 'Activation Test')
+    // fixed_servers is the modal's default mode and needs a real server: a
+    // config with no usable host/port can no longer be saved.
+    await page.getByTestId('single-proxy-host-input').fill('127.0.0.1')
+    await page.getByTestId('single-proxy-port-input').fill('8080')
     await page.getByTestId('modal-save-btn').click()
     // Wait for modal to close
     await expect(page.getByTestId('modal-title')).not.toBeVisible()
@@ -386,6 +406,10 @@ test.describe('4. Proxy Activation & Deactivation', () => {
     await page.getByTestId('add-new-script-btn').click()
     await expect(page.getByTestId('modal-title')).toBeVisible()
     await page.fill('input#scriptName', 'Proxy One')
+    // fixed_servers is the modal's default mode and needs a real server: a
+    // config with no usable host/port can no longer be saved.
+    await page.getByTestId('single-proxy-host-input').fill('127.0.0.1')
+    await page.getByTestId('single-proxy-port-input').fill('8080')
     await page.getByTestId('modal-save-btn').click()
     // Wait for modal to close
     await expect(page.getByTestId('modal-title')).not.toBeVisible()
@@ -394,6 +418,10 @@ test.describe('4. Proxy Activation & Deactivation', () => {
     await page.getByTestId('add-new-script-btn').click()
     await expect(page.getByTestId('modal-title')).toBeVisible()
     await page.fill('input#scriptName', 'Proxy Two')
+    // fixed_servers is the modal's default mode and needs a real server: a
+    // config with no usable host/port can no longer be saved.
+    await page.getByTestId('single-proxy-host-input').fill('127.0.0.1')
+    await page.getByTestId('single-proxy-port-input').fill('8080')
     await page.getByTestId('modal-save-btn').click()
     // Wait for modal to close
     await expect(page.getByTestId('modal-title')).not.toBeVisible()
@@ -426,6 +454,10 @@ test.describe('5. Quick Switch Mode', () => {
     await page.getByTestId('add-new-script-btn').click()
     await expect(page.getByTestId('modal-title')).toBeVisible()
     await page.fill('input#scriptName', 'Quick Switch Test')
+    // fixed_servers is the modal's default mode and needs a real server: a
+    // config with no usable host/port can no longer be saved.
+    await page.getByTestId('single-proxy-host-input').fill('127.0.0.1')
+    await page.getByTestId('single-proxy-port-input').fill('8080')
     await page.getByTestId('modal-save-btn').click()
     // Wait for modal to close
     await expect(page.getByTestId('modal-title')).not.toBeVisible()
@@ -473,6 +505,10 @@ test.describe('5. Quick Switch Mode', () => {
     await page.getByTestId('add-new-script-btn').click()
     await expect(page.getByTestId('modal-title')).toBeVisible()
     await page.fill('input#scriptName', 'Quick Switch Area Test')
+    // fixed_servers is the modal's default mode and needs a real server: a
+    // config with no usable host/port can no longer be saved.
+    await page.getByTestId('single-proxy-host-input').fill('127.0.0.1')
+    await page.getByTestId('single-proxy-port-input').fill('8080')
     await page.getByTestId('modal-save-btn').click()
     // Wait for modal to close
     await expect(page.getByTestId('modal-title')).not.toBeVisible()
@@ -547,6 +583,10 @@ test.describe('7. Backup & Restore', () => {
     await page.getByTestId('add-new-script-btn').click()
     await expect(page.getByTestId('modal-title')).toBeVisible()
     await page.fill('input#scriptName', 'Backup Test Proxy')
+    // fixed_servers is the modal's default mode and needs a real server: a
+    // config with no usable host/port can no longer be saved.
+    await page.getByTestId('single-proxy-host-input').fill('127.0.0.1')
+    await page.getByTestId('single-proxy-port-input').fill('8080')
     await page.getByTestId('modal-save-btn').click()
     // Wait for modal to close
     await expect(page.getByTestId('modal-title')).not.toBeVisible()
@@ -628,6 +668,10 @@ test.describe('9. Color Selection', () => {
     await page.getByTestId('add-new-script-btn').click()
     await expect(page.getByTestId('modal-title')).toBeVisible()
     await page.fill('input#scriptName', 'Color Test')
+    // fixed_servers is the modal's default mode and needs a real server: a
+    // config with no usable host/port can no longer be saved.
+    await page.getByTestId('single-proxy-host-input').fill('127.0.0.1')
+    await page.getByTestId('single-proxy-port-input').fill('8080')
 
     // Choose a non-default color and confirm the bound input took the value
     const colorInput = page.getByTestId('config-color-input')
@@ -762,6 +806,10 @@ test.describe('13. Data Persistence', () => {
     await page.getByTestId('add-new-script-btn').click()
     await expect(page.getByTestId('modal-title')).toBeVisible()
     await page.fill('input#scriptName', 'Persistence Test')
+    // fixed_servers is the modal's default mode and needs a real server: a
+    // config with no usable host/port can no longer be saved.
+    await page.getByTestId('single-proxy-host-input').fill('127.0.0.1')
+    await page.getByTestId('single-proxy-port-input').fill('8080')
     await page.getByTestId('modal-save-btn').click()
 
     // Wait for modal to close
@@ -816,6 +864,10 @@ test.describe('14. Popup Quick Switch Flow', () => {
     await optionsPage.getByTestId('add-new-script-btn').click()
     await expect(optionsPage.getByTestId('modal-title')).toBeVisible()
     await optionsPage.fill('input#scriptName', 'Popup Test Proxy')
+    // fixed_servers is the modal's default mode and needs a real server: a
+    // config with no usable host/port can no longer be saved.
+    await optionsPage.getByTestId('single-proxy-host-input').fill('127.0.0.1')
+    await optionsPage.getByTestId('single-proxy-port-input').fill('8080')
     await optionsPage.getByTestId('modal-save-btn').click()
     // Wait for modal to close
     await expect(optionsPage.getByTestId('modal-title')).not.toBeVisible()

--- a/tests/e2e/proxy-management.spec.ts
+++ b/tests/e2e/proxy-management.spec.ts
@@ -89,7 +89,11 @@ test.describe('Proxy Configuration Management', () => {
     // Fill in configuration name
     await page.fill('input#scriptName', 'Test PAC Script')
 
-    // PAC Script mode is the default, just save
+    // The modal opens on "Connect through a server" (fixed_servers), so switch
+    // to PAC script explicitly rather than relying on a default.
+    await page.getByTestId('conn-type-trigger').click()
+    await page.getByTestId('segment-pac_script').click()
+
     await page.getByTestId('modal-save-btn').click()
 
     // Wait for modal to close
@@ -106,6 +110,10 @@ test.describe('Proxy Configuration Management', () => {
     await page.getByTestId('add-new-script-btn').click()
     await expect(page.locator('text=Proxy Configuration').first()).toBeVisible()
     await page.fill('input#scriptName', 'Delete Test')
+    // fixed_servers is the modal's default mode and needs a real server:
+    // a config with no usable host/port can no longer be saved.
+    await page.getByTestId('single-proxy-host-input').fill('127.0.0.1')
+    await page.getByTestId('single-proxy-port-input').fill('8080')
     await page.getByTestId('modal-save-btn').click()
     // Wait for modal to close
     await expect(page.locator('h2:has-text("Proxy Configuration")').first()).not.toBeVisible()
@@ -128,6 +136,10 @@ test.describe('Proxy Configuration Management', () => {
     await page.getByTestId('add-new-script-btn').click()
     await expect(page.locator('text=Proxy Configuration').first()).toBeVisible()
     await page.fill('input#scriptName', 'Original Name')
+    // fixed_servers is the modal's default mode and needs a real server:
+    // a config with no usable host/port can no longer be saved.
+    await page.getByTestId('single-proxy-host-input').fill('127.0.0.1')
+    await page.getByTestId('single-proxy-port-input').fill('8080')
     await page.getByTestId('modal-save-btn').click()
     // Wait for modal to close
     await expect(page.locator('h2:has-text("Proxy Configuration")').first()).not.toBeVisible()
@@ -164,6 +176,10 @@ test.describe('Quick Switch Functionality', () => {
     await page.getByTestId('add-new-script-btn').click()
     await expect(page.locator('text=Proxy Configuration').first()).toBeVisible()
     await page.fill('input#scriptName', 'Quick Switch Test')
+    // fixed_servers is the modal's default mode and needs a real server:
+    // a config with no usable host/port can no longer be saved.
+    await page.getByTestId('single-proxy-host-input').fill('127.0.0.1')
+    await page.getByTestId('single-proxy-port-input').fill('8080')
     await page.getByTestId('modal-save-btn').click()
     // Wait for modal to close
     await expect(page.locator('h2:has-text("Proxy Configuration")').first()).not.toBeVisible()
@@ -210,6 +226,10 @@ test.describe('Backup and Restore', () => {
     await page.getByTestId('add-new-script-btn').click()
     await expect(page.locator('text=Proxy Configuration').first()).toBeVisible()
     await page.fill('input#scriptName', 'Export Test')
+    // fixed_servers is the modal's default mode and needs a real server:
+    // a config with no usable host/port can no longer be saved.
+    await page.getByTestId('single-proxy-host-input').fill('127.0.0.1')
+    await page.getByTestId('single-proxy-port-input').fill('8080')
     await page.getByTestId('modal-save-btn').click()
     // Wait for modal to close
     await expect(page.locator('h2:has-text("Proxy Configuration")').first()).not.toBeVisible()
@@ -246,5 +266,38 @@ test.describe('Error Handling', () => {
     // Should show validation error or the button should not work
     // Check if modal is still open (indicating validation failed)
     await expect(page.getByTestId('modal-title')).toBeVisible()
+  })
+
+  /**
+   * Regression: a manual proxy saved with the port left blank used to be
+   * accepted. Chrome then rejected the whole config, so activating it left the
+   * popup showing the proxy as ON while traffic went out unproxied — a silent
+   * failure with privacy consequences. Saving must now be refused.
+   *
+   * (An out-of-range port like 99999 was already blocked, but by the browser's
+   * native min/max validation on the number input, not by the app. The empty
+   * case slipped through because the input carries no `required` attribute and
+   * validatePort() treats blank as "no error".)
+   */
+  test('refuses to save a manual proxy whose port is blank', async () => {
+    const page = await getOptionsPage()
+
+    await page.getByTestId('add-new-script-btn').click()
+    await expect(page.getByTestId('modal-title')).toBeVisible()
+    await page.fill('input#scriptName', 'Blank Port Proxy')
+    await page.getByTestId('single-proxy-host-input').fill('127.0.0.1')
+    // port deliberately left empty
+    await page.getByTestId('modal-save-btn').click()
+
+    // The modal stays open and reports the problem instead of saving.
+    await expect(page.getByTestId('modal-title')).toBeVisible()
+    await expect(page.locator('[data-error-message]')).toBeVisible()
+
+    // And nothing was persisted.
+    const saved = await page.evaluate(async () => {
+      const data = await chrome.storage.sync.get(null)
+      return JSON.stringify(data).includes('Blank Port Proxy')
+    })
+    expect(saved).toBe(false)
   })
 })


### PR DESCRIPTION
Follow-up to #89, which surfaced this while removing `BrowserService`.

## The bug

A manual proxy saved with the **port left blank** was accepted, stored as `port: ''`, and forwarded to `chrome.proxy.settings.set()`. Chrome rejects the *entire* payload when any server is malformed, so the setting never took effect — but the extension still marked the config active.

**The popup showed the proxy as ON while traffic went out unproxied, with no error anywhere.** For anyone relying on the proxy for privacy, that's a silent failure in the worst direction.

Confirmed end to end before the fix:

| Step | Observed |
|---|---|
| Save with blank port | succeeds |
| Storage | `{"host":"127.0.0.1","port":"","scheme":"http"}` |
| Activate | `activeScriptId` set, `isActive: true`, popup shows it selected |
| `chrome.proxy.settings.get` | `{"mode":"system"}`, `levelOfControl: "controllable_by_this_extension"` |
| Fetch | `ORIGIN_OK` — **direct, unproxied** |

An out-of-range port like `99999` was already blocked, but by the browser's native `min`/`max` validation on the number input — not by the app. The empty case slipped through because the input has no `required` attribute and `validatePort()` treats blank as "no error".

## Root cause

One type doing two jobs. `ChromeProxyConfig.rules` was the app's own `ProxyRules`, where `port` is the string an `<input>` yields and what we persist. Chrome wants a number. Reusing one type for both contracts is what let an unconvertible value through — and `BrowserService` (removed in #89) typed the parameter `unknown`, so nothing checked it either.

## The fix

- **Split the Chrome-facing shape.** `ChromeProxyServer`/`ChromeProxyRules` carry `port: number`. App types keep `string` — correct for a form field and for JSON storage, and every other boundary (the FoxyProxy and SwitchyOmega exporters, the importers) already converts.
- **`toChromeProxyServer()`** is the single "usable" predicate: host present, port parsing to 1–65535. Unfilled per-protocol entries are dropped rather than forwarded, since the form renders an input group per protocol and the unused ones arrive empty.
- **Fail loudly.** A `fixed_servers` config with no usable server now throws. `setProxy` is wrapped in `withErrorHandling`, so users with an already-broken stored config get a visible error instead of silent unproxied traffic.
- **Save gate** reuses `toChromeProxyServer`, so the form and the apply step cannot disagree about what is valid. Uses the existing `invalidProxyPort` message — no new locale keys, no parity risk.
- **`fromChromeProxyRules()`** fixes the inverse leak: `detectCurrentProxy` assigned Chrome's rules straight into storage, writing numeric ports into a field the rest of the app reads as a string.
- Dropped the cast added in #89; the payload is now genuinely type-checked.

## The test suite was asserting on the bug

**17 e2e tests** were creating `fixed_servers` proxies with no host and no port and asserting success. They passed only because the app accepted unusable configs.

The clearest case: the whole **`2. PAC Script Configuration - Full CRUD`** block never selected PAC mode. The modal defaults to `fixed_servers`, so those four tests were creating empty *server* configs and calling them PAC scripts — a stale comment, *"PAC Script mode is the default, just save"*, records where the misunderstanding came from. Section 2 now selects PAC mode explicitly; the remaining thirteen supply a real server.

## Reviewer notes

- **"Add proxy → type a name → save" now fails** where it used to appear to succeed. That is the intended change.
- **Users with an existing broken config** will now see an error on activation rather than silence. Better, but it is a visible change for them.

## Verification

- 506 unit pass (11 new converter tests covering blank/blank-ish/non-numeric/0/65536/missing-host, plus the already-numeric shape `detectCurrentProxy` used to write)
- `svelte-check`: 4053 files, 0 errors
- `biome ci`: clean (2 pre-existing warnings in untouched files)
- Build succeeds
- **55 e2e pass in real Chrome**, including a new regression test asserting a blank-port proxy cannot be saved and is not persisted